### PR TITLE
WIP: Added model, cft and example apigateway resource

### DIFF
--- a/examples/apigateway.yaml
+++ b/examples/apigateway.yaml
@@ -1,0 +1,8 @@
+apiVersion: operator.aws/v1alpha1
+kind: ApiGateway
+metadata:
+  name: foobar-proxy
+spec:
+  nlbDNSName: <DNS NAME FOR NLB>
+  nlbArn: <NLB ARN>
+  

--- a/examples/cloudformationtemplates/apigateway.yaml
+++ b/examples/cloudformationtemplates/apigateway.yaml
@@ -1,0 +1,96 @@
+apiVersion: operator.aws/v1alpha1
+kind: CloudFormationTemplate
+metadata:
+  name: apigateway
+data:
+  key: apigateway.yaml
+  template: | 
+    AWSTemplateFormatVersion: 2010-09-09
+    Description: 'AWS Operator - Amazon DynamoDB'
+    Parameters:
+      Namespace:
+        Description: >-
+          This is the namespace for the Kubernetes object.
+        Type: String
+      ResourceVersion:
+        Type: String
+        Description: >-
+          This is the resource version for the Kubernetes object.
+      ResourceName:
+        Description: >-
+          This is the resource name for the Kubernetes object
+        Type: String
+      ClusterName:
+        Description: >-
+          This is the cluster name for the operator
+        Type: String
+      NLBDNSName:
+        Description: >-
+          This is the service URL to the API Gateway should proxy requests to.
+        Type: String
+      NLBArn:
+        Description: >-
+          This is the NLB Arn for the VPCLink.
+        Type: String
+    Resources:
+      VPCLink:
+        Type: AWS::ApiGateway::VpcLink
+        Properties:
+          Name: !Join
+            - ''
+            -  [!Ref 'ResourceName', '-vpclink']
+          TargetArns:
+            - !Ref 'NLBArn'
+      RestAPI:
+        Type: AWS::ApiGateway::RestApi
+        Properties:
+          Name: !Ref 'ResourceName'
+          EndpointConfiguration: 
+            Types:
+              - REGIONAL
+      Resource:
+        Type: AWS::ApiGateway::Resource
+        Properties:
+          ParentId: !GetAtt 'RestAPI.RootResourceId'
+          RestApiId: !Ref 'RestAPI'
+          PathPart: '{proxy+}'  
+      Method:
+        Type: AWS::ApiGateway::Method
+        Properties:
+          RestApiId: !Ref RestAPI
+          ResourceId: !Ref Resource
+          HttpMethod: 'ANY'
+          AuthorizationType: 'AWS_IAM'
+          RequestParameters:
+            "method.request.path.proxy": true
+          Integration:
+            ConnectionId: !Ref 'VPCLink'
+            ConnectionType: 'VPC_LINK'
+            IntegrationHttpMethod: 'ANY'
+            PassthroughBehavior: 'WHEN_NO_MATCH'
+            RequestParameters:
+              "integration.request.path.proxy": "method.request.path.proxy"
+              "integration.request.header.Accept-Encoding": "'identity'"
+            Type: 'HTTP_PROXY'
+            Uri: !Join
+              - ''
+              - ['http://', !Ref 'NLBDNSName']
+          MethodResponses:
+            - ResponseModels:
+                "application/json": "Empty"
+              StatusCode: '200'
+      Deployment: 
+        DependsOn: 
+          - VPCLink
+          - RestAPI
+          - Resource
+          - Method
+        Type: AWS::ApiGateway::Deployment
+        Properties: 
+          RestApiId: !Ref RestAPI
+          StageName: "prod"
+    Outputs:
+      ApiGatewayEndpointURL:
+        Value: !Join
+          - ""
+          - ["https://", !Ref Deployment, ".execute-api.", !Ref 'AWS::Region', '.amazonaws.com/prod']

--- a/models/apigateway.yaml
+++ b/models/apigateway.yaml
@@ -1,0 +1,49 @@
+apiVersion: operator.aws/v1alpha1
+kind: ModelDefinition
+metadata:
+  name: ApiGatewayResource
+spec:
+  kind: ApiGateway
+  type: Spec 
+  queue: true
+  useCloudFormation: true
+  resource:
+    name: apigateway
+    plural: apigateways
+    shortNames:
+    - name: apigw
+  body:
+    schema:
+      type: object
+      properties:  
+      - key: nlbDNSName
+        type: string
+        description: |
+          Fill this out
+        structKey: NLBDNSName
+        templateKey: NLBDNSName
+      - key: nlbArn
+        type: string
+        description: |
+          Fill this out
+        structKey: NLBArn
+        templateKey: NLBArn
+  output:
+    schema:
+      type: object
+      properties:
+      - key: apiGatewayEndpoint
+        type: string
+        description: |
+          Fill this out
+        structKey: ApiGatewayEndpoint
+        templateKey: ApiGatewayEndpoint
+
+  additionalResources:
+    services:
+    - name: apiGatewayEndpoint
+      type: ExternalName
+      externalName: '{{ .Obj.Output.ApiGatewayEndpoint }}'
+      ports:
+      - port: 443
+  


### PR DESCRIPTION
Issue #86 

This PR adds the ModelDefinition (and associated examples) for creating an API Gateway Reverse Proxy for a Kubernetes service

The APIGateway resources manages the VPCLink and RestAPI for a single stage which proxies all traffic to an HTTP service exposed via a Kubernetes service with type "LoadBalancer" and with the appropriate annotations for [creating an NLB](https://aws.amazon.com/blogs/opensource/network-load-balancer-support-in-kubernetes-1-9/).  (k8s 1.9+)

The APIGateway resource requires the NLB DNS name and ARN - however it would be ideal to just provide the DNSName since it's already available through the k8s service resource.

I'm gonna have to keep this PR open for a minute (which might give us a chance to figure out if this is a sane path - at least as a first pass) since I'm heading to Japan tomorrow -> Oct 13th 2018.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
