### PR TITLE
Add helm chart

### DIFF
--- a/charts/aws-service-operator/Chart.yaml
+++ b/charts/aws-service-operator/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+name: aws-service-operator
+version: 0.0.1
+description: The AWS Service Operator allows you to manage AWS resources using Kubernetes Custom Resource Definitions.
+keywords:
+  - AWS
+home: https://github.com/awslabs/aws-service-operator
+sources:
+  - https://github.com/awslabs/aws-service-operator
+maintainers:
+  - name: christopherhein
+    email: heichris@amazon.com
+  - name: acaire
+    email: ash.caire@gmail.com
+engine: gotpl
+appVersion: v0.0.1-alpha2
+tillerVersion: ">=2.8.0"

--- a/charts/aws-service-operator/README.md
+++ b/charts/aws-service-operator/README.md
@@ -1,0 +1,47 @@
+# AWS Service Operator
+
+This is the Helm chart for the [AWS Service Operator](https://github.com/awslabs/aws-service-operator)
+
+## Prerequisites
+
+- Kubernetes 1.9+
+
+## Installing the chart
+Create AWS resources with Kubernetes
+The chart can be installed by running:
+
+```bash
+$ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+$ helm install incubator/aws-service-operator
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the aws-service-operator chart and their default values.
+
+| Parameter                 | Description                            | Default                                            |
+| ------------------------- | -------------------------------------- | -------------------------------------------------- |
+| `image.repository`        | Container image repository             | `awsserviceoperator/aws-service-operator`          |
+| `image.tag`               | Container image tag                    | `v0.0.1-alpha2`                                    |
+| `image.pullPolicy`        | Container pull policy                  | `IfNotPresent`                                     |
+| `operator.accountId`      | AWS Account ID to operator on          | `""`                                               |
+| `operator.bucket`         | Base bucket to store resources in      | `aws-operator`                                     |
+| `operator.clusterName`    | Used to label generated CF templates   | `aws-operator`                                     |
+| `operator.config`         | Config file                            | `$HOME/.aws-operator.yaml`                         |
+| `operator.kubeconfig`     | Path to local kubeconfig file          | `""`                                               |
+| `operator.logfile`        | Log file                               | `""`                                               |
+| `operator.loglevel`       | Log level                              | `Info`                                             |
+| `operator.region`         | AWS Region for created resources       | `us-west-2`                                        |
+| `operator.resources`      | Comma Delimited list of CRDS to deploy | `s3bucket,dynamodb`                                |
+| `affinity`                | affinity settings for pod assignment   | `{}`                                               |
+| `extraArgs`               | Optional CLI argument                  | `[]`                                               |
+| `extraEnv`                | Optional environment variables         | `[]`                                               |
+| `extraVolumes`            | Custom Volumes                         | `[]`                                               |
+| `extraVolumeMounts`       | Custom VolumeMounts                    | `[]`                                               |
+| `nodeSelector`            | Node labels for pod assignment         | `{}`                                               |
+| `podAnnotations`          | Annotations to attach to pod           | `{}`                                               |
+| `rbac.create`             | Create RBAC roles                      | `true`                                             |
+| `rbac.serviceAccountName` | Existing ServiceAccount to use         | `default`                                          |
+| `replicas`                | Deployment replicas                    | `1`                                                |
+| `resources`               | container resource requests and limits | `{}`                                               |
+| `tolerations`             | Toleration labels for pod assignment   | `[]`                                               |

--- a/charts/aws-service-operator/templates/NOTES.txt
+++ b/charts/aws-service-operator/templates/NOTES.txt
@@ -1,0 +1,10 @@
+Thank you for installing the {{ .Chart.Name }} chart.
+
+For more information on configuring {{ .Chart.Name }}, refer to {{ .Chart.Home }}
+
+Your release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get {{ .Release.Name }}

--- a/charts/aws-service-operator/templates/_helpers.tpl
+++ b/charts/aws-service-operator/templates/_helpers.tpl
@@ -1,0 +1,61 @@
+{{/*
+Helm standard labels.
+*/}}
+{{- define "aws-service-operator.helmStandardLabels" -}}
+app.kubernetes.io/name: {{ include "aws-service-operator.name" . }}
+helm.sh/chart: {{ include "aws-service-operator.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+{{- end -}}
+
+{{/*
+Helm pod labels.
+*/}}
+{{- define "aws-service-operator.helmPodLabels" -}}
+app.kubernetes.io/name: {{ include "aws-service-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "aws-service-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "aws-service-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "aws-service-operator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "aws-service-operator.serviceAccountName" -}}
+{{- if .Values.rbac.create -}}
+    {{ default (include "aws-service-operator.fullname" .) .Values.rbac.serviceAccountName }}
+{{- else -}}
+    {{ default "default" .Values.rbac.serviceAccountName }}
+{{- end -}}
+{{- end -}}

--- a/charts/aws-service-operator/templates/clusterrole.yaml
+++ b/charts/aws-service-operator/templates/clusterrole.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "aws-service-operator.fullname" . }}
+  labels:
+{{ include "aws-service-operator.helmStandardLabels" . | indent 4 }}
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    - pods
+    - configmaps
+    - services
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - update
+  - apiGroups:
+    - extensions
+    resources:
+    - thirdpartyresources
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - update
+  - apiGroups:
+    - apiextensions.k8s.io
+    resources:
+    - customresourcedefinitions
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+  - apiGroups:
+    - service-operator.aws
+    resources:
+    - "*"
+    verbs:
+    - "*"
+{{- end -}}

--- a/charts/aws-service-operator/templates/clusterrolebinding.yaml
+++ b/charts/aws-service-operator/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "aws-service-operator.fullname" . }}
+  labels:
+{{ include "aws-service-operator.helmStandardLabels" . | indent 4 }}
+roleRef:
+  name: {{ template "aws-service-operator.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+subjects:
+  - name: {{ template "aws-service-operator.fullname" . }}
+    kind: ServiceAccount
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/aws-service-operator/templates/crd.yaml
+++ b/charts/aws-service-operator/templates/crd.yaml
@@ -1,0 +1,129 @@
+apiVersion: v1
+kind: List
+items:
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: cloudformationtemplates.service-operator.aws
+  spec:
+    group: service-operator.aws
+    names:
+      kind: CloudFormationTemplate
+      listKind: CloudFormationTemplateList
+      plural: cloudformationtemplates
+      shortNames:
+      - cft
+      - cfts
+      - cfn
+      - cfns
+      - cloudformation
+      singular: cloudformationtemplates
+    scope: Namespaced
+    version: v1alpha1
+
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: dynamodbs.service-operator.aws
+  spec:
+    group: service-operator.aws
+    names:
+      kind: DynamoDB
+      listKind: DynamoDBList
+      plural: dynamodbs
+      shortNames:
+      - ddb
+      - ddbs
+      - dynamo
+      - dynamotable
+      - dynamotables
+      singular: dynamodbs
+    scope: Namespaced
+    version: v1alpha1
+
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: ecrrepositories.service-operator.aws
+  spec:
+    group: service-operator.aws
+    names:
+      kind: ECRRepository
+      listKind: ECRRepositoryList
+      plural: ecrrepositories
+      shortNames:
+      - ecr
+      - repository
+      singular: ecrrepositories
+    scope: Namespaced
+    version: v1alpha1
+
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: s3buckets.service-operator.aws
+  spec:
+    group: service-operator.aws
+    names:
+      kind: S3Bucket
+      listKind: S3BucketList
+      plural: s3buckets
+      shortNames:
+      - s3
+      - bucket
+      - buckets
+      singular: s3buckets
+    scope: Namespaced
+    version: v1alpha1
+
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: snssubscriptions.service-operator.aws
+  spec:
+    group: service-operator.aws
+    names:
+      kind: SNSSubscription
+      listKind: SNSSubscriptionList
+      plural: snssubscriptions
+      shortNames:
+      - subscription
+      singular: snssubscriptions
+    scope: Namespaced
+    version: v1alpha1
+
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: snstopics.service-operator.aws
+  spec:
+    group: service-operator.aws
+    names:
+      kind: SNSTopic
+      listKind: SNSTopicList
+      plural: snstopics
+      shortNames:
+      - sns
+      - topic
+      - topics
+      singular: snstopics
+    scope: Namespaced
+    version: v1alpha1
+
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: sqsqueues.service-operator.aws
+  spec:
+    group: service-operator.aws
+    names:
+      kind: SQSQueue
+      listKind: SQSQueueList
+      plural: sqsqueues
+      shortNames:
+      - sqs
+      - queue
+      - queues
+      singular: sqsqueues
+    scope: Namespaced
+    version: v1alpha1

--- a/charts/aws-service-operator/templates/deployment.yaml
+++ b/charts/aws-service-operator/templates/deployment.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "aws-service-operator.fullname" . }}
+  labels:
+{{ include "aws-service-operator.helmStandardLabels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+{{ include "aws-service-operator.helmPodLabels" . | indent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- end }}
+      labels:
+{{ include "aws-service-operator.helmPodLabels" . | indent 8 }}
+    spec:
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{ end }}
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "aws-service-operator.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      containers:
+        - name: aws-service-operator
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - server
+            {{ if .Values.operator }}
+            {{ if .Values.operator.accountId }}
+            - --account-id={{ .Values.operator.accountId }}
+            {{- end }}
+            {{- if .Values.operator.bucket }}
+            - --bucket={{ .Values.operator.bucket }}
+            {{- end }}
+            {{- if .Values.operator.clusterName }}
+            - --cluster-name={{ .Values.operator.clusterName }}
+            {{- end }}
+            {{- if .Values.operator.config }}
+            - --config={{ .Values.operator.config }}
+            {{- end }}
+            {{- if .Values.operator.kubeconfig }}
+            - --kubeconfig={{ .Values.operator.kubeconfig }}
+            {{- end }}
+            {{- if .Values.operator.logfile }}
+            - --logfile={{ .Values.operator.logfile }}
+            {{- end }}
+            {{- if .Values.operator.loglevel }}
+            - --loglevel={{ .Values.operator.loglevel }}
+            {{- end }}
+            {{- if .Values.operator.region }}
+            - --region={{ .Values.operator.region }}
+            {{- end }}
+            {{- if .Values.operator.resources }}
+            - --resources={{ .Values.operator.resources }}
+            {{- end }}
+            {{- range $key, $value := .Values.extraArgs }}
+            {{- if $value }}
+            - --{{ $key }}={{ $value }}
+            {{- else }}
+            - --{{ $key }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+          {{- if .Values.affinity }}
+          affinity:
+{{ toYaml .Values.affinity | indent 12 }}
+          {{- end }}
+          {{- if .Values.extraEnv}}
+          env:
+            {{- range $key, $value := .Values.extraEnv }}
+            - name: {{ $key }}
+              value: {{ $value }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.resources }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          {{- end }}
+          {{- if .Values.tolerations }}
+          tolerations:
+{{ toYaml .Values.tolerations | indent 12 }}
+          {{- end }}
+{{- if .Values.extraVolumeMounts }}
+          volumeMounts:
+{{ toYaml .Values.extraVolumeMounts | indent 12 }}
+{{- end }}
+{{- if .Values.extraVolumes }}
+      volumes:
+{{ toYaml .Values.extraVolumes | indent 8 }}
+{{- end }}

--- a/charts/aws-service-operator/templates/serviceaccount.yaml
+++ b/charts/aws-service-operator/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.rbac.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+{{ include "aws-service-operator.helmStandardLabels" . | indent 4 }}
+  name: {{ template "aws-service-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/aws-service-operator/values.yaml
+++ b/charts/aws-service-operator/values.yaml
@@ -1,0 +1,74 @@
+# Default values for aws-service-operator
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+image:
+  repository: awsserviceoperator/aws-service-operator
+  tag: v0.0.1-alpha2
+  pullPolicy: IfNotPresent
+
+## App config
+operator:
+  #accountId: 123456789012
+  #bucket: aws-operator
+  #clusterName: aws-operator
+  #config: "$HOME/.aws-operator.yaml"
+  #kubeconfig:
+  #logfile:
+  #loglevel:
+  #region: us-west-2
+  #resources: s3bucket,dynamodb
+
+## Pod Affinity
+affinity: {}
+
+## Extra args to pass to aws-service-operator
+extraArgs:
+  #- --help
+
+## A list of additional environment variables
+extraEnv:
+  #- name: my_env
+  #  value: my_value
+
+## Additional Volumes and mounts
+extraVolumes:
+  #- hostPath:
+  #    path: /var/log
+  #  name: logs
+extraVolumeMounts:
+  #- name: logs
+  #  mountPath: /host/var/log
+  #  readOnly: true
+
+## Node Selector
+nodeSelector:
+  #disktype: ssd
+
+## Pod Annotations
+podAnnotations:
+  #iam.amazonaws.com/role: arn:aws:iam::<ACCOUNT_ID>:role/aws-service-operator
+
+## Deployment replica count
+replicas: 1
+
+## RBAC roles and bindings
+rbac:
+  create: true
+  # Ignored if rbac.create is true
+  serviceAccountName: default
+
+## Pod Resources
+resources:
+  #requests:
+  #  memory: "64Mi"
+  #  cpu: "250m"
+  #limits:
+  #  memory: "128Mi"
+  #  cpu: "500m"
+
+## Pod Tolerations
+tolerations:
+  #- key: "node.kubernetes.io/not-ready"
+  #  operator: "Exists"
+  #  effect: "NoExecute"
+  #  tolerationSeconds: 6000

--- a/cmd/aws-service-operator/main.go
+++ b/cmd/aws-service-operator/main.go
@@ -46,7 +46,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&kubeconfig, "kubeconfig", "k", "", "Path to local kubeconfig file (mainly used for development)")
 	rootCmd.PersistentFlags().StringVarP(&awsRegion, "region", "r", "us-west-2", "AWS Region for resources to be created in")
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "loglevel", "l", "Info", "Log level for the CLI")
-	rootCmd.PersistentFlags().StringVarP(&logFile, "logfile", "", "", "Log level for the CLI")
+	rootCmd.PersistentFlags().StringVarP(&logFile, "logfile", "", "", "Log file for the CLI")
 	rootCmd.PersistentFlags().StringVarP(&resources, "resources", "", "cloudformationtemplate,dynamodb,ecrrepository,s3bucket,snssubscription,snstopic,sqsqueue", "Comma delimited list of CRDs to deploy")
 	rootCmd.PersistentFlags().StringVarP(&clusterName, "cluster-name", "i", "aws-operator", "Cluster name for the Application to run as, used to label the Cloudformation templated to avoid conflict")
 	rootCmd.PersistentFlags().StringVarP(&bucket, "bucket", "b", "aws-operator", "To configure the operator you need a base bucket to contain the resources")

--- a/readme.adoc
+++ b/readme.adoc
@@ -1,9 +1,9 @@
 = AWS Service Operator
 
 The AWS Service Operator allows you to manage AWS resources using
-Kubernetes Custom Resource Definitions. 
+Kubernetes Custom Resource Definitions.
 
-Using the AWS Service Operator enables a `gitops` workflow to drive your infrastructure to the desired state leveraging Kubernetes Custom Resource Definitions (CRD), the Kubernetes internal control loop, and AWS cloudformation orchestration.  Read more about "operators" link:https://coreos.com/operators/[here].
+Using the AWS Service Operator enables a `gitops` workflow to drive your infrastructure to the desired state leveraging Kubernetes Custom Resource Definitions (CRD), the Kubernetes internal control loop, and AWS CloudFormation orchestration.  Read more about "operators" link:https://coreos.com/operators/[here].
 
 image::aws-service-operator-example.gif[]
 
@@ -22,18 +22,18 @@ Make sure your Kubernetes cluster is up and running and you've configured your a
 === IAM permissions management
 
 You will need to install an IAM management layer
-such as `kube2iam`. This will allow you to use an AWS IAM role to manage a pod's 
-access to AWS resources. 
+such as `kube2iam`. This will allow you to use an AWS IAM role to manage a pod's
+access to AWS resources.
 
-To get started with `kube2iam` go link:https://github.com/jtblin/kube2iam[here] or check out the 
+To get started with `kube2iam` go link:https://github.com/jtblin/kube2iam[here] or check out the
 link:https://github.com/helm/charts/tree/master/stable/kube2iam[helm chart]
 
-The `aws-service-operator` runs as a pod in your Kubernetes cluster and listens for new `aws` type CRDs.  
-When a new CRD is created the operator will create the resource in AWS via cloudformation and 
+The `aws-service-operator` runs as a pod in your Kubernetes cluster and listens for new `aws` type CRDs.
+When a new CRD is created the operator will create the resource in AWS via CloudFormation and
 create a Kubernetes `Service` for access within the cluster.
 
 === Create an IAM role for the `aws-service-operator`
- 
+
  The `K8S_WORKER_NODE_IAM_ROLE` is the IAM role assigned to your kubernetes worker instances.
 
 [source,shell]
@@ -42,7 +42,7 @@ aws cloudformation create-stack \
   --capabilities CAPABILITY_NAMED_IAM \
   --template-body file://configs/aws-service-operator-role.yaml \
   --parameters \
-    ParameterKey=WorkerArn,ParameterValue=<K8S_WORKER_NODE_IAM_ROLE>    
+    ParameterKey=WorkerArn,ParameterValue=<K8S_WORKER_NODE_IAM_ROLE>
 
 Your resulting IAM role arn should look something like `arn:aws:iam::<ACCOUNT_ID>:role/aws-service-operator`
 
@@ -51,7 +51,7 @@ Your resulting IAM role arn should look something like `arn:aws:iam::<ACCOUNT_ID
 Before applying these resources make sure to replace the following placeholders with the approriate information in `configs/aws-service-operator.yaml`
 
 - `<ACCOUNT_ID>` - Your AWS Account ID
-- `<REGION>` - The AWS Region you're working in 
+- `<REGION>` - The AWS Region you're working in
 - `<CLUSTER_NAME>` - The name of your cluster
 - `<BUCKET_NAME>` - (optional) The operator stores certain things in s3 create a bucket or provide an existing bucket for the operator to use `i.e. aws s3 mb s3://foobar`
 
@@ -60,7 +60,7 @@ Before applying these resources make sure to replace the following placeholders 
 [source,shell]
 kubectl apply -f configs/aws-service-operator.yaml
 
-.2. Create the cloudformation templates (cft) used by the operator
+.2. Create the CloudFormation templates (cft) used by the operator
 [source,shell]
 kubectl apply -f examples/cloudformationtemplates
 
@@ -68,11 +68,11 @@ kubectl apply -f examples/cloudformationtemplates
 [source,shell]
 kubectl logs -f -n aws-service-operator deploy/aws-service-operator
 
-.4. Create an ecr repository with the operator
+.4. Create an ECR repository with the operator
 [source,yaml]
 kubectl apply -f examples/ecrrepository.yaml
 
-The operator will communicate directly with Cloudformation to create the ecr repository using
+The operator will communicate directly with CloudFormation to create the ECR repository using
 the parameters you have passed in. If you'd like to see the progress you can
 view the status directly via `kubectl`.
 
@@ -82,9 +82,9 @@ kubectl describe ecr example-repository-name
 
 == Removing everything
 
-If you would like to tear everything down - run the following commands. 
+If you would like to tear everything down - run the following commands.
 
-*IMPORTANT* this will not remove anything you created with the AWS cli (ecr repo for the operator itself, IAM roles etc.)
+*IMPORTANT* this will not remove anything you created with the AWS CLI (ECR repo for the operator itself, IAM roles etc.)
 
 [source,shell]
 kubectl delete ecr example-repository-name


### PR DESCRIPTION
Attempt to address #82

*Description of changes:*
Adds a Helm chart for aws-service-operator and correct a minor typo with some perceived brand consistency.  Happy to drop the last commit if necessary - I haven't tested it heavily, feel free to change anything you need to :)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
