### PR TITLE
Allow PATCH Event Resource

### DIFF
--- a/code-generation/pkg/codegen/assets/aws-service-operator.yaml.templ
+++ b/code-generation/pkg/codegen/assets/aws-service-operator.yaml.templ
@@ -41,6 +41,7 @@ items:
     - pods
     - configmaps
     - services
+    - events
     verbs:
     - get
     - list
@@ -48,6 +49,7 @@ items:
     - create
     - delete
     - update
+    - patch
   - apiGroups:
     - apiextensions.k8s.io
     resources:


### PR DESCRIPTION
While testing the master branch I noticed this error

```
'events "foobarfoobarfoobarfoobarfoobarfoobar.155e2c1afd13d7ce" is forbidden:
User "system:serviceaccount:aws-service-operator:aws-service-operator" cannot
patch events in the namespace "default"' (will not retry!)
```

I updated the cluster role definition to allow this action

Signed-off-by: Alexander Tanton <tantonat@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
