### PR TITLE
Fix watching cloudformation template resources

### DIFF
--- a/cmd/aws-service-operator/main.go
+++ b/cmd/aws-service-operator/main.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -9,8 +12,6 @@ import (
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
-	"strings"
 )
 
 var (
@@ -45,7 +46,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&awsRegion, "region", "r", "us-west-2", "AWS Region for resources to be created in")
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "loglevel", "l", "Info", "Log level for the CLI")
 	rootCmd.PersistentFlags().StringVarP(&logFile, "logfile", "", "", "Log level for the CLI")
-	rootCmd.PersistentFlags().StringVarP(&resources, "resources", "", "cloudformationtemplates,dynamodb,ecrrepository,s3bucket,snssubscription,snstopic,sqsqueue", "Comma delimited list of CRDs to deploy")
+	rootCmd.PersistentFlags().StringVarP(&resources, "resources", "", "cloudformationtemplate,dynamodb,ecrrepository,s3bucket,snssubscription,snstopic,sqsqueue", "Comma delimited list of CRDs to deploy")
 	rootCmd.PersistentFlags().StringVarP(&clusterName, "cluster-name", "i", "aws-operator", "Cluster name for the Application to run as, used to label the Cloudformation templated to avoid conflict")
 	rootCmd.PersistentFlags().StringVarP(&bucket, "bucket", "b", "aws-operator", "To configure the operator you need a base bucket to contain the resources")
 	rootCmd.PersistentFlags().StringVarP(&accountID, "account-id", "a", "", "AWS Account ID, this is used to configure outputs and operate on the proper account.")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,15 +1,10 @@
 package server
 
 import (
-	// "fmt"
-	// "github.com/aws/aws-sdk-go/aws"
-	// "github.com/aws/aws-sdk-go/aws/ec2metadata"
-	// "github.com/aws/aws-sdk-go/aws/session"
-
 	awsscheme "github.com/awslabs/aws-service-operator/pkg/client/clientset/versioned/scheme"
-	//awsclient "github.com/awslabs/aws-service-operator/pkg/client/clientset/versioned/typed/service-operator.aws/v1alpha1"
 	"github.com/awslabs/aws-service-operator/pkg/config"
 	opBase "github.com/awslabs/aws-service-operator/pkg/operators/base"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -39,7 +34,8 @@ func (c *Server) Run(stopChan chan struct{}) {
 	config.Recorder = recorder
 
 	// start watching the aws operator resources
-	logger.Info("Watching the resources")
+	logger.WithFields(logrus.Fields{"resources": config.Resources}).Info("Watching")
+
 	operators := opBase.New(config) // TODO: remove context and Clientset
 	err := operators.Watch(corev1.NamespaceAll, stopChan)
 	if err != nil {


### PR DESCRIPTION
This PR fixes a bug in the default resource names passed to the --resources
command line arg.  This bug caused the cft operator to not watch for changes on
the cft resource.

Signed-off-by: Alexander Tanton <tantonat@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
