### PR TITLE
Fixed url construction to work with all regions

### DIFF
--- a/pkg/customizations/cloudformationtemplate/cloudformationtemplate.go
+++ b/pkg/customizations/cloudformationtemplate/cloudformationtemplate.go
@@ -2,6 +2,8 @@ package cloudformationtemplate
 
 import (
 	"bytes"
+	"reflect"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -9,7 +11,6 @@ import (
 	awsclient "github.com/awslabs/aws-service-operator/pkg/client/clientset/versioned/typed/service-operator.aws/v1alpha1"
 	"github.com/awslabs/aws-service-operator/pkg/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"reflect"
 )
 
 // OnAdd will be fired when you add a new CFT
@@ -82,7 +83,7 @@ func updateOutput(config *config.Config, cft *awsV1alpha1.CloudFormationTemplate
 	resourceCopy := resource.DeepCopy()
 	resourceCopy.Status.ResourceStatus = status
 	resourceCopy.Status.ResourceStatusReason = reason
-	resourceCopy.Output.URL = "https://" + config.Bucket + ".s3-" + config.Region + ".amazonaws.com/" + cft.Data.Key
+	resourceCopy.Output.URL = "https://s3." + config.Region + ".amazonaws.com/" + config.Bucket + "/" + cft.Data.Key
 
 	_, err = clientSet.CloudFormationTemplates(cft.Namespace).Update(resourceCopy)
 	if err != nil {

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -2,15 +2,17 @@ package helpers
 
 import (
 	"bytes"
-	"github.com/aws/aws-sdk-go/service/cloudformation"
-	awsclient "github.com/awslabs/aws-service-operator/pkg/client/clientset/versioned/typed/service-operator.aws/v1alpha1"
-	"github.com/awslabs/aws-service-operator/pkg/config"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
 	"text/template"
+
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	awsclient "github.com/awslabs/aws-service-operator/pkg/client/clientset/versioned/typed/service-operator.aws/v1alpha1"
+	"github.com/awslabs/aws-service-operator/pkg/config"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // KubernetesResourceName returns the resource name for other components
@@ -101,5 +103,11 @@ func GetCloudFormationTemplate(config *config.Config, rType string, name string,
 		logger.WithError(err).Error("error getting cloudformation template returning fallback template")
 		return "https://s3-us-west-2.amazonaws.com/cloudkit-templates/" + rType + ".yaml"
 	}
+
+	logger.WithFields(logrus.Fields{
+		"namespace": cNamespace,
+		"name":      cName,
+		"url":       resource.Output.URL,
+	}).Info("found cloudformation template")
 	return resource.Output.URL
 }


### PR DESCRIPTION
* added log line for debugging
* us-east-1 has a slightly different hostname so the previous url generation
wasn't working for stacks in us-east-1 see
https://docs.aws.amazon.com/general/latest/gr/rande.html

Signed-off-by: Alexander Tanton <tantonat@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
