### PR TITLE
Fix generation of deepcopy funcs

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -13,5 +13,5 @@ ${CODEGEN_PKG}/generate-groups.sh all \
   github.com/awslabs/aws-service-operator/pkg/client \
   github.com/awslabs/aws-service-operator/pkg/apis \
   "service-operator.aws:v1alpha1" \
-  --output-base "$(dirname ${BASH_SOURCE})/../../.." \
+  --output-base "${GOPATH}/src" \
   --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt


### PR DESCRIPTION
Signed-off-by: Alexander Tanton <tantonat@amazon.com>

This PR fixes an issue with generating deepcopy funcs.  The relative paths used in output-dir was causing issues. I replaced it with the `GOPATH` since this should always be set in a dev env.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
