### PR TITLE
expose prometheus metrics endpoint

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,6 +1,9 @@
 package server
 
 import (
+	"fmt"
+	"net/http"
+
 	awsscheme "github.com/awslabs/aws-service-operator/pkg/client/clientset/versioned/scheme"
 	"github.com/awslabs/aws-service-operator/pkg/config"
 	opBase "github.com/awslabs/aws-service-operator/pkg/operators/base"
@@ -9,6 +12,8 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const controllerName = "aws-service-operator"
@@ -20,25 +25,50 @@ func New(config *config.Config) *Server {
 	}
 }
 
+func (c *Server) exposeMetrics(errChan chan error) {
+	http.Handle("/metrics", promhttp.Handler())
+	err := http.ListenAndServe(":9090", nil)
+	if err != nil {
+		errChan <- fmt.Errorf("unable to expose metrics: %v", err)
+	}
+}
+
+func (c *Server) watchOperatorResources(errChan chan error, stopChan chan struct{}) {
+
+	logger := c.Config.Logger
+
+	logger.Info("getting kubernetes context")
+	awsscheme.AddToScheme(scheme.Scheme)
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(logger.Infof)
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: c.Config.KubeClientset.CoreV1().Events("")})
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerName})
+	c.Config.Recorder = recorder
+
+	// start watching the aws operator resources
+	logger.WithFields(logrus.Fields{"resources": c.Config.Resources}).Info("Watching")
+	operators := opBase.New(c.Config) // TODO: remove context and Clientset
+	err := operators.Watch(corev1.NamespaceAll, stopChan)
+	if err != nil {
+		errChan <- fmt.Errorf("unable to watch resources: %v", err)
+	}
+}
+
 // Run starts the server to listen to Kubernetes
 func (c *Server) Run(stopChan chan struct{}) {
 	config := c.Config
 	logger := config.Logger
-	logger.Info("getting kubernetes context")
+	errChan := make(chan error, 1)
 
-	awsscheme.AddToScheme(scheme.Scheme)
-	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(logger.Infof)
-	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: config.KubeClientset.CoreV1().Events("")})
-	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerName})
-	config.Recorder = recorder
+	logger.Info("starting metrics server")
+	go c.exposeMetrics(errChan)
 
-	// start watching the aws operator resources
-	logger.WithFields(logrus.Fields{"resources": config.Resources}).Info("Watching")
+	logger.Info("starting resource watcher")
+	go c.watchOperatorResources(errChan, stopChan)
 
-	operators := opBase.New(config) // TODO: remove context and Clientset
-	err := operators.Watch(corev1.NamespaceAll, stopChan)
+	err := <-errChan
 	if err != nil {
-		logger.Infof("error watching operators '%s'\n", err)
+		logger.Fatal(err)
 	}
+
 }


### PR DESCRIPTION
This change exposes a simple Prometheus `/metrics` endpoint as part of #111. This adds the listener and exposes the default promhttp metrics. I think we should introduce further instrumentation as part of #111 after some discussion of what is important to monitor to start with, but it's worth adding this default set on it's own.

*Issue #, if available:* #111 

*Description of changes:*
- expose simple metrics via promhttp handler at /metrics
- run operator and metrics handler as goroutines

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
