### PR TITLE
Minor Makefile Tweak

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ tag:
 
 .PHONY: install-aws-codegen
 install-aws-codegen:
-	go install -ldflags "-X main.commit=$(commitSHA) -X main.date=$(dateStr)" ./code-generation/cmd/aws-service-operator-codegen
+	${MAKE} -C code-generation install
 
 .PHONY: aws-codegen
 aws-codegen:

--- a/code-generation/Makefile
+++ b/code-generation/Makefile
@@ -5,6 +5,10 @@ dateStr := $(shell date +%s)
 build:
 	go build -ldflags "-X main.commit=$(commitSHA) -X main.date=$(dateStr)" ./cmd/aws-service-operator-codegen
 
+.PHONY: install
+install: rebuild
+	go install -ldflags "-X main.commit=$(commitSHA) -X main.date=$(dateStr)" ./cmd/aws-service-operator-codegen
+
 .PHONY: install-bindata
 install-bindata:
 	go get -u github.com/jteeuwen/go-bindata/...


### PR DESCRIPTION
*Description of changes:* This shifts the logic of how to install the code generation components into the Makefile for the code generation code. It also will rebuild the code generation tool before installing. This ensures the latest templates are bundled and included in the binary before use.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
