### PR TITLE
Internalize codegen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,13 @@ tag:
 install-aws-codegen:
 	${MAKE} -C code-generation install
 
+.PHONY: build-codegen
+build-codegen:
+	${MAKE} -C code-generation rebuild
+
 .PHONY: aws-codegen
-aws-codegen:
-	aws-service-operator-codegen process
+aws-codegen: build-codegen
+	./code-generation/aws-service-operator-codegen process
 
 .PHONY: k8s-codegen
 k8s-codegen:

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ build-codegen:
 	${MAKE} -C code-generation rebuild
 
 .PHONY: aws-codegen
-aws-codegen: build-codegen
+aws-codegen:
 	./code-generation/aws-service-operator-codegen process
 
 .PHONY: k8s-codegen
@@ -43,4 +43,4 @@ k8s-codegen:
 codegen: aws-codegen k8s-codegen
 
 .PHONY: rebuild
-rebuild: codegen build
+rebuild: build-codegen codegen build

--- a/code-generation/Makefile
+++ b/code-generation/Makefile
@@ -16,6 +16,7 @@ install-bindata:
 .PHONY: update-bindata
 update-bindata:
 	go generate ./pkg/codegen/
+	go fmt ./...
 
 .PHONY: rebuild
 rebuild: update-bindata build


### PR DESCRIPTION
Related to #62

*Description of changes:* This removes the need to separately install the codegen component. `make build-codegen` or `make rebuild` will handle preparing things. `make aws-codegen` (and callers) will then use the local binary.

It will also format the bindata code if it changes to preserve formatting.

Installation of go-bindata is still required. It would be nice to run this from a vendored source for consistency, maybe that can be a future effort.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
