### PR TITLE
Update Documentation for installing codegen tool

### DIFF
--- a/development.adoc
+++ b/development.adoc
@@ -3,7 +3,8 @@
 Before start working on the AWS Service Operator please read the
 link:contributing.adoc[Contributing Guidelines].
 
-Make sure you first have all the dependencies installed.
+Make sure you first have all the dependencies installed. The source checkout
+should be under your $GOPATH/src directory.
 
 [source,shell]
 ----
@@ -18,7 +19,10 @@ running.
 
 [source,shell]
 ----
-go get -u github.com/christopherhein/aws-operator-codegen
+cd code-generation
+make install-bindata
+cd ..
+make install-aws-codegen
 ----
 
 After you have this installed you can run the following from the root of the


### PR DESCRIPTION
- Documentation for installing codegen points to a non-existent repository. Updated docs
  to install from the source code added to the main repository in commit hash
  14e267972349d82bacdd7e65a674fa46ce0e6cac and use the included make files.

Signed-off-by: Robert Marshall <rmarshall@gitlab.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
