### PR TITLE
Fix Helm Chart so extraArgs and extraEnv render correctly

### DIFF
--- a/charts/aws-service-operator/templates/deployment.yaml
+++ b/charts/aws-service-operator/templates/deployment.yaml
@@ -57,13 +57,9 @@ spec:
             {{- if .Values.operator.resources }}
             - --resources={{ .Values.operator.resources }}
             {{- end }}
-            {{- range $key, $value := .Values.extraArgs }}
-            {{- if $value }}
-            - --{{ $key }}={{ $value }}
-            {{- else }}
-            - --{{ $key }}
             {{- end }}
-            {{- end }}
+            {{- range $arg := .Values.extraArgs }}
+            - {{ $arg }}
             {{- end }}
           {{- if .Values.affinity }}
           affinity:
@@ -71,9 +67,9 @@ spec:
           {{- end }}
           {{- if .Values.extraEnv}}
           env:
-            {{- range $key, $value := .Values.extraEnv }}
-            - name: {{ $key }}
-              value: {{ $value }}
+            {{- range $env := .Values.extraEnv }}
+            - name: {{ $env.name }}
+              value: {{ $env.value }}
             {{- end }}
           {{- end }}
           {{- if .Values.resources }}


### PR DESCRIPTION
**Issue:** https://github.com/awslabs/aws-service-operator/issues/150

*Description of changes:*
Fix Helm Chart so extraArgs and extraEnv render correctly.

**Testing:**
Can test/validate by using a values file (`test.yaml`) whose contents are exactly as per the default `values.yaml`, but with the addition of testing `--key=value` extraArgs items render properly:
```
extraEnv:
  - name: my_env
    value: my_value

extraArgs:
  - --help
  - --foo=bar
```
`helm template ./aws-service-operator/ -f test.yaml`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
