### PR TITLE
Convert link from Markdown to AsciiDoc

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -93,7 +93,7 @@ kubectl delete -f configs/aws-service-operator.yaml
 
 == Developer Docs
 
-[Here](development.adoc)
+link:development.adoc[Here]
 
 = FAQ
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

A trivial change of a link in the README, which was in Markdown and not AsciiDoc format. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
