### PR TITLE
fix the error when deploy SQS with UsedeadletterQueue to a region doesn't support FifoQueue

### DIFF
--- a/cloudformation/sqsqueue.yaml
+++ b/cloudformation/sqsqueue.yaml
@@ -109,7 +109,10 @@ Resources:
     Condition: CreateDeadLetterQueue
     Type: 'AWS::SQS::Queue'
     Properties:
-      FifoQueue: !Ref FifoQueue
+      FifoQueue: !If
+        - IsFifo
+        - 'true'
+        - !Ref AWS::NoValue
 Outputs:
   QueueURL:
     Description: URL of newly created SQS Queue

--- a/examples/cloudformationtemplates/sqsqueue.yaml
+++ b/examples/cloudformationtemplates/sqsqueue.yaml
@@ -116,7 +116,10 @@ data:
         Condition: CreateDeadLetterQueue
         Type: 'AWS::SQS::Queue'
         Properties:
-          FifoQueue: !Ref FifoQueue
+          FifoQueue: !If
+            - IsFifo
+            - 'true'
+            - !Ref AWS::NoValue
     Outputs:
       QueueURL:
         Description: URL of newly created SQS Queue


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Set `FifoQueue` as `AWS::NoValue` if `FifoQueue` not enabled.
The check exists for the `SQSQueue`, not for `MyDeadLetterQueue`, that when deployed to a region without FifoQueue feature, it will fail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
