### PR TITLE
helm chart: add CRD for ElasticCache

### DIFF
--- a/charts/aws-service-operator/templates/clusterrole.yaml
+++ b/charts/aws-service-operator/templates/clusterrole.yaml
@@ -13,6 +13,7 @@ rules:
     - pods
     - configmaps
     - services
+    - events
     verbs:
     - get
     - list
@@ -20,17 +21,7 @@ rules:
     - create
     - delete
     - update
-  - apiGroups:
-    - extensions
-    resources:
-    - thirdpartyresources
-    verbs:
-    - get
-    - list
-    - watch
-    - create
-    - delete
-    - update
+    - patch
   - apiGroups:
     - apiextensions.k8s.io
     resources:

--- a/charts/aws-service-operator/templates/crd.yaml
+++ b/charts/aws-service-operator/templates/crd.yaml
@@ -61,6 +61,22 @@ items:
 - apiVersion: apiextensions.k8s.io/v1beta1
   kind: CustomResourceDefinition
   metadata:
+    name: elasticaches.service-operator.aws
+  spec:
+    group: service-operator.aws
+    names:
+      kind: ElastiCache
+      listKind: ElastiCacheList
+      plural: elasticaches
+      shortNames:
+      - ec
+      singular: elasticaches
+    scope: Namespaced
+    version: v1alpha1
+
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
     name: s3buckets.service-operator.aws
   spec:
     group: service-operator.aws


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add the CRD for `ElasticCache` to the helm chart, thereby synchronizing `charts/aws-service-operator/templates/crd.yaml` with `configs/aws-service-operator.yaml`.

Also sync `charts/aws-service-operator-templates/clusterrole.yaml` with `configs/aws-service-operator.yaml`: add `events` and `patch`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
