### PR TITLE
examples: fix YAML syntax in cloudformationtemplate/s3bucket

### DIFF
--- a/examples/cloudformationtemplates/s3bucket.yaml
+++ b/examples/cloudformationtemplates/s3bucket.yaml
@@ -163,12 +163,13 @@ data:
               - "s3:GetObject"
               Effect: Allow
               Principal: "*"
-              Resource: !Join:
-                - ""
-                -
-                  - "arn:aws:s3:::"
-                  - !Ref S3bucket
-                    - "/*
+              Resource:
+                Fn::Join:
+                  - ""
+                  -
+                    - "arn:aws:s3:::"
+                    - !Ref S3bucket
+                    - "/*"
 
       LoggingBucket:
         Condition: UseLogging


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This fixes a YAML syntax error in the example cloudformation template for s3buckets.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
