### PR TITLE
Add QueueName

### DIFF
--- a/cloudformation/sqsqueue.yaml
+++ b/cloudformation/sqsqueue.yaml
@@ -86,6 +86,7 @@ Resources:
   SQSQueue:
     Type: 'AWS::SQS::Queue'
     Properties:
+      QueueName: !Ref ResourceName
       ContentBasedDeduplication: !If
         - IsFifo
         - !Ref ContentBasedDeduplication

--- a/examples/cloudformationtemplates/sqsqueue.yaml
+++ b/examples/cloudformationtemplates/sqsqueue.yaml
@@ -93,6 +93,7 @@ data:
       SQSQueue:
         Type: 'AWS::SQS::Queue'
         Properties:
+          QueueName: !Ref ResourceName
           ContentBasedDeduplication: !If
             - IsFifo
             - !Ref ContentBasedDeduplication


### PR DESCRIPTION
*Description of changes:*

The default queue naming convention (e.g. `clustername-sqsqueue-resourcename-namespace-SQSQueue-1018QW2THSWKZ`) is rather unpredictable and unreadable. Why not just use resource name for setting queue name like it's done in S3/ECR/etc. resources?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
