### PR TITLE
Add ability to scope API calls to a kubernetes namespace

### DIFF
--- a/cmd/aws-service-operator/main.go
+++ b/cmd/aws-service-operator/main.go
@@ -15,14 +15,14 @@ import (
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-        
-        _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 var (
 	// cfgFile, masterURL, kubeConfig, awsRegion all help support passed in flags into the server
-	cfgFile, masterURL, kubeconfig, awsRegion, logLevel, logFile, resources, clusterName, bucket, accountID string
-	defaultNamespace                                                                                        string
+	cfgFile, masterURL, kubeconfig, awsRegion, logLevel, logFile, resources, clusterName, bucket, accountID, k8sNamespace string
+	defaultNamespace                                                                                                      string
 
 	// rootCmd represents the base command when called without any subcommands
 	rootCmd = &cobra.Command{
@@ -56,6 +56,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&clusterName, "cluster-name", "i", "aws-operator", "Cluster name for the Application to run as, used to label the Cloudformation templated to avoid conflict")
 	rootCmd.PersistentFlags().StringVarP(&bucket, "bucket", "b", "aws-operator", "To configure the operator you need a base bucket to contain the resources")
 	rootCmd.PersistentFlags().StringVarP(&accountID, "account-id", "a", "", "AWS Account ID, this is used to configure outputs and operate on the proper account.")
+	rootCmd.PersistentFlags().StringVarP(&k8sNamespace, "k8s-namespace", "", "", "Namespace to scope k8s API queries to. If left blank will default to all namespaces")
 	rootCmd.PersistentFlags().StringVarP(&defaultNamespace, "default-namespace", "", "default", "The default namespace in which to look for CloudFormation templates")
 
 	viper.BindPFlag("config", rootCmd.PersistentFlags().Lookup("config"))
@@ -154,6 +155,7 @@ func getConfig() (c config.Config, err error) {
 		Bucket:           bucket,
 		AccountID:        accountID,
 		DefaultNamespace: defaultNamespace,
+		K8sNamespace:     k8sNamespace,
 		QueueURL:         queueURL,
 		QueueARN:         queueARN,
 	}

--- a/code-generation/pkg/codegen/assets/aws-service-operator.yaml.templ
+++ b/code-generation/pkg/codegen/assets/aws-service-operator.yaml.templ
@@ -110,3 +110,4 @@ items:
             - --cluster-name=<CLUSTER_NAME>
             - --region=<REGION>
             - --account-id=<ACCOUNT_ID>
+            - --k8s-namespace=<K8S_NAMESPACE>

--- a/code-generation/pkg/codegen/assets/operator.go.templ
+++ b/code-generation/pkg/codegen/assets/operator.go.templ
@@ -77,7 +77,8 @@ func QueueUpdater(config config.Config, msg *queuemanager.MessageBody) error {
 		namespace = msg.Namespace
 	} else {
 		clientSet, _ := awsclient.NewForConfig(config.RESTConfig)
-		resources, err := clientSet.{{.Spec.PluralName}}("").List(metav1.ListOptions{})
+
+		resources, err := clientSet.{{.Spec.PluralName}}(config.K8sNamespace).List(metav1.ListOptions{})
 		if err != nil {
 			logger.WithError(err).Error("error getting {{.Spec.Resource.Plural}}")
 			return err

--- a/configs/aws-service-operator.yaml
+++ b/configs/aws-service-operator.yaml
@@ -235,3 +235,4 @@ items:
             - --cluster-name=<CLUSTER_NAME>
             - --region=<REGION>
             - --account-id=<ACCOUNT_ID>
+            - --k8s-namespace=<K8S_NAMESPACE>

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	Bucket           string
 	AccountID        string
 	DefaultNamespace string
+	K8sNamespace     string
 	Recorder         record.EventRecorder
 }
 

--- a/pkg/operators/dynamodb/operator.go
+++ b/pkg/operators/dynamodb/operator.go
@@ -65,7 +65,8 @@ func QueueUpdater(config config.Config, msg *queuemanager.MessageBody) error {
 		namespace = msg.Namespace
 	} else {
 		clientSet, _ := awsclient.NewForConfig(config.RESTConfig)
-		resources, err := clientSet.DynamoDBs("").List(metav1.ListOptions{})
+
+		resources, err := clientSet.DynamoDBs(config.K8sNamespace).List(metav1.ListOptions{})
 		if err != nil {
 			logger.WithError(err).Error("error getting dynamodbs")
 			return err

--- a/pkg/operators/ecrrepository/operator.go
+++ b/pkg/operators/ecrrepository/operator.go
@@ -65,7 +65,8 @@ func QueueUpdater(config config.Config, msg *queuemanager.MessageBody) error {
 		namespace = msg.Namespace
 	} else {
 		clientSet, _ := awsclient.NewForConfig(config.RESTConfig)
-		resources, err := clientSet.ECRRepositories("").List(metav1.ListOptions{})
+
+		resources, err := clientSet.ECRRepositories(config.K8sNamespace).List(metav1.ListOptions{})
 		if err != nil {
 			logger.WithError(err).Error("error getting ecrrepositories")
 			return err

--- a/pkg/operators/elasticache/operator.go
+++ b/pkg/operators/elasticache/operator.go
@@ -65,7 +65,8 @@ func QueueUpdater(config config.Config, msg *queuemanager.MessageBody) error {
 		namespace = msg.Namespace
 	} else {
 		clientSet, _ := awsclient.NewForConfig(config.RESTConfig)
-		resources, err := clientSet.ElastiCaches("").List(metav1.ListOptions{})
+
+		resources, err := clientSet.ElastiCaches(config.K8sNamespace).List(metav1.ListOptions{})
 		if err != nil {
 			logger.WithError(err).Error("error getting elasticaches")
 			return err

--- a/pkg/operators/s3bucket/operator.go
+++ b/pkg/operators/s3bucket/operator.go
@@ -65,7 +65,8 @@ func QueueUpdater(config config.Config, msg *queuemanager.MessageBody) error {
 		namespace = msg.Namespace
 	} else {
 		clientSet, _ := awsclient.NewForConfig(config.RESTConfig)
-		resources, err := clientSet.S3Buckets("").List(metav1.ListOptions{})
+
+		resources, err := clientSet.S3Buckets(config.K8sNamespace).List(metav1.ListOptions{})
 		if err != nil {
 			logger.WithError(err).Error("error getting s3buckets")
 			return err

--- a/pkg/operators/snssubscription/operator.go
+++ b/pkg/operators/snssubscription/operator.go
@@ -65,7 +65,8 @@ func QueueUpdater(config config.Config, msg *queuemanager.MessageBody) error {
 		namespace = msg.Namespace
 	} else {
 		clientSet, _ := awsclient.NewForConfig(config.RESTConfig)
-		resources, err := clientSet.SNSSubscriptions("").List(metav1.ListOptions{})
+
+		resources, err := clientSet.SNSSubscriptions(config.K8sNamespace).List(metav1.ListOptions{})
 		if err != nil {
 			logger.WithError(err).Error("error getting snssubscriptions")
 			return err

--- a/pkg/operators/snstopic/operator.go
+++ b/pkg/operators/snstopic/operator.go
@@ -65,7 +65,8 @@ func QueueUpdater(config config.Config, msg *queuemanager.MessageBody) error {
 		namespace = msg.Namespace
 	} else {
 		clientSet, _ := awsclient.NewForConfig(config.RESTConfig)
-		resources, err := clientSet.SNSTopics("").List(metav1.ListOptions{})
+
+		resources, err := clientSet.SNSTopics(config.K8sNamespace).List(metav1.ListOptions{})
 		if err != nil {
 			logger.WithError(err).Error("error getting snstopics")
 			return err

--- a/pkg/operators/sqsqueue/operator.go
+++ b/pkg/operators/sqsqueue/operator.go
@@ -65,7 +65,8 @@ func QueueUpdater(config config.Config, msg *queuemanager.MessageBody) error {
 		namespace = msg.Namespace
 	} else {
 		clientSet, _ := awsclient.NewForConfig(config.RESTConfig)
-		resources, err := clientSet.SQSQueues("").List(metav1.ListOptions{})
+
+		resources, err := clientSet.SQSQueues(config.K8sNamespace).List(metav1.ListOptions{})
 		if err != nil {
 			logger.WithError(err).Error("error getting sqsqueues")
 			return err

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -57,8 +57,9 @@ func (c *Server) watchOperatorResources(errChan chan error, ctx context.Context)
 		logger.WithError(err).Error("error setting queue policy")
 	}
 
-	logger.WithFields(logrus.Fields{"resources": c.Config.Resources}).Info("Watching")
-	go operators.Watch(ctx, corev1.NamespaceAll)
+	k8sNamespaceToWatch := c.Config.K8sNamespace
+	logger.WithFields(logrus.Fields{"resources": c.Config.Resources, "in namespace": k8sNamespaceToWatch}).Info("Watching")
+	go operators.Watch(ctx, k8sNamespaceToWatch)
 	go queue.Subscribe(c.Config, queueManager, ctx)
 	<-ctx.Done()
 	c.Config.Logger.Info("operators stopped")

--- a/readme.adoc
+++ b/readme.adoc
@@ -54,6 +54,7 @@ Before applying these resources make sure to replace the following placeholders 
 - `<REGION>` - The AWS Region you're working in
 - `<CLUSTER_NAME>` - The name of your cluster
 - `<BUCKET_NAME>` - (optional) The operator stores certain things in s3 create a bucket or provide an existing bucket for the operator to use `i.e. aws s3 mb s3://foobar`
+- `<K8S_NAMESPACE>` - (optional) This will scope kubernetes API calls to a specific namespace. If used consider adding a namespace to the resources defined in `configs/aws-service-operator.yaml`
 
 
 .1. Create the operator


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Allow a namespace to be passed as an optional configuration parameter. When passed this namespace will be used when querying the kubernetes API to allow the operator to be scoped to a namespace.

Combined with using `Role` and `RoleBinding` instead of `ClusterRole` and `ClusterRoleBinding` when deploying the operator, this allows the operator to be run with namespace-scoped permissions.

The default behaviour if no namespace is passed in is to use all namespaces as it does currently.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
