### PR TITLE
Add bucket param to operator config args

### DIFF
--- a/configs/aws-service-operator.yaml
+++ b/configs/aws-service-operator.yaml
@@ -236,3 +236,4 @@ items:
             - --region=<REGION>
             - --account-id=<ACCOUNT_ID>
             - --k8s-namespace=<K8S_NAMESPACE>
+            - --bucket=<BUCKET_NAME>

--- a/readme.adoc
+++ b/readme.adoc
@@ -53,7 +53,7 @@ Before applying these resources make sure to replace the following placeholders 
 - `<ACCOUNT_ID>` - Your AWS Account ID
 - `<REGION>` - The AWS Region you're working in
 - `<CLUSTER_NAME>` - The name of your cluster
-- `<BUCKET_NAME>` - (optional) The operator stores certain things in s3 create a bucket or provide an existing bucket for the operator to use `i.e. aws s3 mb s3://foobar`
+- `<BUCKET_NAME>` - The operator stores certain things in s3, create a bucket or provide an existing bucket for the operator to use `i.e. aws s3 mb s3://foobar`
 - `<K8S_NAMESPACE>` - (optional) This will scope kubernetes API calls to a specific namespace. If used consider adding a namespace to the resources defined in `configs/aws-service-operator.yaml`
 
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-service-operator/issues/193

*Description of changes:*
This change adds the `bucket` param to the operator deployment config. It also makes a minor change to the documentation, removing the optional tag from creating an S3 bucket. As with out the use of an S3 bucket a user encounters a number of errors when creating the cloudformation templates.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
