### PR TITLE
explicilty use bash to run hack/update-codegen.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ aws-codegen:
 
 .PHONY: k8s-codegen
 k8s-codegen:
-	./hack/update-codegen.sh
+	bash ./hack/update-codegen.sh
 
 .PHONY: codegen
 codegen: aws-codegen k8s-codegen


### PR DESCRIPTION
*Issue #195 *

*Description of changes:*

Invoke bash explicitly in the Makefile when running hack/update-codegen.sh

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
