### PR TITLE
correct the <K8S_NAMESPACE> argument name

### DIFF
--- a/code-generation/pkg/codegen/assets/aws-service-operator.yaml.templ
+++ b/code-generation/pkg/codegen/assets/aws-service-operator.yaml.templ
@@ -110,4 +110,4 @@ items:
             - --cluster-name=<CLUSTER_NAME>
             - --region=<REGION>
             - --account-id=<ACCOUNT_ID>
-            - --k8s-namespace=<K8S_NAMESPACE>
+            - --default-namespace=<K8S_NAMESPACE>

--- a/configs/aws-service-operator.yaml
+++ b/configs/aws-service-operator.yaml
@@ -235,4 +235,4 @@ items:
             - --cluster-name=<CLUSTER_NAME>
             - --region=<REGION>
             - --account-id=<ACCOUNT_ID>
-            - --k8s-namespace=<K8S_NAMESPACE>
+            - --default-namespace=<K8S_NAMESPACE>


### PR DESCRIPTION
*Issue #191 *

*Description of changes:*

Use the correct argument name, which is `default-namespace` https://github.com/awslabs/aws-service-operator/blob/76312848693937324f5920d771cde1abe2f51fdd/cmd/aws-service-operator/main.go#L60

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
