### PR TITLE
Add a link to the containers-roadmap issue

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -1,5 +1,7 @@
 = AWS Service Operator
 
+*See https://github.com/aws/containers-roadmap/issues/456 for a discussion around the future of this project*
+
 The AWS Service Operator allows you to manage AWS resources using
 Kubernetes Custom Resource Definitions.
 


### PR DESCRIPTION
There have been a few issues that have popped up recently asking about the future of this project, if it's still active, etc.  Linking to the issue in containers-roadmap could prevent those and direct people to the right place off the bat.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
