### PR TITLE
Fix fetching cloudformationtemplate object from k8s

### DIFF
--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -89,11 +89,13 @@ func GetCloudFormationTemplate(config config.Config, rType string, name string, 
 	logger := config.Logger
 	clientSet, _ := awsclient.NewForConfig(config.RESTConfig)
 
-	var cName string
-	var cNamespace string
+	cName := name
+	cNamespace := namespace
+
 	if name == "" {
 		cName = rType
 	}
+
 	if namespace == "" {
 		cNamespace = config.DefaultNamespace
 	}


### PR DESCRIPTION
*Issue #, if available:*

Fixes #209 

*Description of changes:*

Currently, when fetching cloudformation template object from Kubernetes, we
fail to fetch the object from a specific namespace, even if the namespace
is specified in the spec for an AWS service object like S3Bucket, etc., and
coerce to using the 'default' namespace, which may not contain the cloudformation
template objects.

This pull request allows fetching cloudformation temaplate objects from
specified namespaces.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
